### PR TITLE
refactor: 수정 시 새로운 document 생성 안되도록 수정 & 최근 화장품 조회 API 수정

### DIFF
--- a/src/main/java/site/cleanfree/be_main/diary/application/DiaryService.java
+++ b/src/main/java/site/cleanfree/be_main/diary/application/DiaryService.java
@@ -8,6 +8,7 @@ import site.cleanfree.be_main.diary.dto.DiaryWriteRequestDto;
 import site.cleanfree.be_main.diary.dto.GetDiaryListDto;
 
 import java.util.List;
+import site.cleanfree.be_main.diary.dto.RecentCosmeticsResponseDto;
 
 @Service
 public interface DiaryService {
@@ -20,5 +21,5 @@ public interface DiaryService {
 
     BaseResponse<List<GetDiaryListDto>> getDiaryList(String token);
 
-    BaseResponse<DiaryResponseDto> getRecentDiaryById(String token);
+    BaseResponse<RecentCosmeticsResponseDto> getRecentDiaryById(String token);
 }

--- a/src/main/java/site/cleanfree/be_main/diary/application/impl/DiaryServiceImpl.java
+++ b/src/main/java/site/cleanfree/be_main/diary/application/impl/DiaryServiceImpl.java
@@ -15,6 +15,7 @@ import site.cleanfree.be_main.diary.dto.DiaryUpdateRequestDto;
 import site.cleanfree.be_main.diary.dto.DiaryWriteRequestDto;
 import site.cleanfree.be_main.diary.dto.DiaryResponseDto;
 import site.cleanfree.be_main.diary.dto.GetDiaryListDto;
+import site.cleanfree.be_main.diary.dto.RecentCosmeticsResponseDto;
 import site.cleanfree.be_main.diary.infrastructure.DiaryRepository;
 import site.cleanfree.be_main.security.JwtTokenProvider;
 
@@ -235,12 +236,12 @@ public class DiaryServiceImpl implements DiaryService {
     }
 
     @Override
-    public BaseResponse<DiaryResponseDto> getRecentDiaryById(String token) {
+    public BaseResponse<RecentCosmeticsResponseDto> getRecentDiaryById(String token) {
         String memberUuid = getMemberUuid(token);
         Optional<Diary> diaryOpt = diaryRepository.findTopByMemberUuidOrderByWriteTimeDesc(memberUuid);
 
         if (diaryOpt.isEmpty()) {
-            return BaseResponse.<DiaryResponseDto>builder()
+            return BaseResponse.<RecentCosmeticsResponseDto>builder()
                 .success(true)
                 .errorCode(ErrorStatus.SUCCESS.getCode())
                 .message("Not exist diary")
@@ -248,19 +249,12 @@ public class DiaryServiceImpl implements DiaryService {
                 .build();
         }
         Diary diary = diaryOpt.get();
-        return BaseResponse.<DiaryResponseDto>builder()
+        return BaseResponse.<RecentCosmeticsResponseDto>builder()
             .success(true)
             .errorCode(ErrorStatus.SUCCESS.getCode())
             .message("Find Recent diary success")
-            .data(DiaryResponseDto.builder()
-                .diaryId(diary.getDiaryId())
-                .skinStatus(diary.getSkinStatus())
-                .thumbnailUrl(diary.getThumbnailUrl())
+            .data(RecentCosmeticsResponseDto.builder()
                 .cosmetics(diary.getCosmetics())
-                .isAlcohol(diary.isAlcohol())
-                .isExercise(diary.isExercise())
-                .sleepTime(diary.getSleepTime())
-                .memo(diary.getMemo())
                 .writeTime(diary.getWriteTime())
                 .build())
             .build();

--- a/src/main/java/site/cleanfree/be_main/diary/domain/Diary.java
+++ b/src/main/java/site/cleanfree/be_main/diary/domain/Diary.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import site.cleanfree.be_main.common.MongoBaseTimeEntity;
 import site.cleanfree.be_main.diary.state.SkinStatus;
@@ -20,6 +21,7 @@ public class Diary extends MongoBaseTimeEntity {
 
     @Id
     private String id;
+    @Indexed(unique = true)
     private String diaryId;
     private String memberUuid;
     private SkinStatus skinStatus;

--- a/src/main/java/site/cleanfree/be_main/diary/dto/RecentCosmeticsResponseDto.java
+++ b/src/main/java/site/cleanfree/be_main/diary/dto/RecentCosmeticsResponseDto.java
@@ -1,0 +1,16 @@
+package site.cleanfree.be_main.diary.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class RecentCosmeticsResponseDto {
+
+    private List<String> cosmetics;
+    private LocalDate writeTime;
+}

--- a/src/main/java/site/cleanfree/be_main/diary/presentation/DiaryController.java
+++ b/src/main/java/site/cleanfree/be_main/diary/presentation/DiaryController.java
@@ -23,6 +23,7 @@ import site.cleanfree.be_main.diary.dto.DiaryWriteRequestDto;
 import site.cleanfree.be_main.diary.dto.GetDiaryListDto;
 
 import java.util.List;
+import site.cleanfree.be_main.diary.dto.RecentCosmeticsResponseDto;
 
 @RestController
 @Slf4j
@@ -68,7 +69,7 @@ public class DiaryController {
 
     @GetMapping("/recent")
     @Operation(summary = "최근 일지 조회 API", description = "최근 일지를 조회합니다. 없으면 null, 빈리스트로 응답합니다.")
-    public ResponseEntity<BaseResponse<DiaryResponseDto>> getRecentDiary(
+    public ResponseEntity<BaseResponse<RecentCosmeticsResponseDto>> getRecentDiary(
         @RequestHeader String Authorization
     ) {
         return ResponseEntity.ok(diaryService.getRecentDiaryById(Authorization));


### PR DESCRIPTION
- #30 
- document의 diaryId 필드에 unique를 걸어 수정된 document가 새로운 document로 생성되지 않도록 했습니다.
- 최근 일지 조회 API를 최근 화장품 조회 API로 수정했습니다.