### PR TITLE
refactor: 최근 화장품 조회 응답에 기본 썸네일 이미지 추가

### DIFF
--- a/src/main/java/site/cleanfree/be_main/diary/application/impl/DiaryServiceImpl.java
+++ b/src/main/java/site/cleanfree/be_main/diary/application/impl/DiaryServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import site.cleanfree.be_main.common.BaseResponse;
 import site.cleanfree.be_main.common.TimeConvertor;
@@ -34,6 +35,8 @@ import static site.cleanfree.be_main.common.TimeConvertor.convertWriteTime;
 @Slf4j
 public class DiaryServiceImpl implements DiaryService {
 
+    @Value("${defaultThumbnailUrl}")
+    private String defaultThumbnailUrl;
     private final JwtTokenProvider jwtTokenProvider;
     private final DiaryRepository diaryRepository;
 
@@ -247,6 +250,7 @@ public class DiaryServiceImpl implements DiaryService {
                 .errorCode(ErrorStatus.SUCCESS.getCode())
                 .message("Not exist diary")
                 .data(RecentCosmeticsResponseDto.builder()
+                    .thumbnailUrl(defaultThumbnailUrl)
                     .cosmetics(new ArrayList<>())
                     .build())
                 .build();
@@ -257,6 +261,7 @@ public class DiaryServiceImpl implements DiaryService {
             .errorCode(ErrorStatus.SUCCESS.getCode())
             .message("Find Recent diary success")
             .data(RecentCosmeticsResponseDto.builder()
+                .thumbnailUrl(defaultThumbnailUrl)
                 .cosmetics(diary.getCosmetics())
                 .writeTime(diary.getWriteTime())
                 .build())

--- a/src/main/java/site/cleanfree/be_main/diary/dto/RecentCosmeticsResponseDto.java
+++ b/src/main/java/site/cleanfree/be_main/diary/dto/RecentCosmeticsResponseDto.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 @Builder
 public class RecentCosmeticsResponseDto {
 
+    private String thumbnailUrl;
     private List<String> cosmetics;
     private LocalDate writeTime;
 }


### PR DESCRIPTION
- [x] #36 
- s3 주소 노출을 방지하기 위해 application.yml에서 기본 썸네일 주소를 불러오도록 했습니다.