### PR TITLE
fix: 일지 리스트 조회 시 기본 썸네일 응답하도록 수정

### DIFF
--- a/src/main/java/site/cleanfree/be_main/diary/application/impl/DiaryServiceImpl.java
+++ b/src/main/java/site/cleanfree/be_main/diary/application/impl/DiaryServiceImpl.java
@@ -193,6 +193,11 @@ public class DiaryServiceImpl implements DiaryService {
             getDiaryListDto.setDayDifference(dayDifference);
             // 반환 시, writeTime 형식 변환
             getDiaryListDto.setWriteTime(convertWriteTime(getDiaryListDto.getWriteTime()));
+
+            String thumbnailUrl = getDiaryListDto.getThumbnailUrl();
+            if (thumbnailUrl == null || thumbnailUrl.isEmpty()) {
+                getDiaryListDto.setThumbnailUrl(defaultThumbnailUrl);
+            }
         }
 
         return BaseResponse.successResponse(
@@ -250,7 +255,6 @@ public class DiaryServiceImpl implements DiaryService {
                 .errorCode(ErrorStatus.SUCCESS.getCode())
                 .message("Not exist diary")
                 .data(RecentCosmeticsResponseDto.builder()
-                    .thumbnailUrl(defaultThumbnailUrl)
                     .cosmetics(new ArrayList<>())
                     .build())
                 .build();
@@ -261,7 +265,6 @@ public class DiaryServiceImpl implements DiaryService {
             .errorCode(ErrorStatus.SUCCESS.getCode())
             .message("Find Recent diary success")
             .data(RecentCosmeticsResponseDto.builder()
-                .thumbnailUrl(defaultThumbnailUrl)
                 .cosmetics(diary.getCosmetics())
                 .writeTime(diary.getWriteTime())
                 .build())

--- a/src/main/java/site/cleanfree/be_main/diary/dto/GetDiaryListDto.java
+++ b/src/main/java/site/cleanfree/be_main/diary/dto/GetDiaryListDto.java
@@ -17,6 +17,10 @@ public class GetDiaryListDto {
     private String writeTime;
     private SkinStatus skinStatus;
 
+    public void setThumbnailUrl(String defaultThumbnailUrl) {
+        this.thumbnailUrl = defaultThumbnailUrl;
+    }
+
     public void setDayDifference(String dayDifference) {
         this.dayDifference = dayDifference;
     }


### PR DESCRIPTION
일지 리스트 조회할때 이미지가 없는 일지는 기본 썸네일 이미지(로고)를 응답하도록 수정했습니다.